### PR TITLE
test: Don't run tests on startup during docker image building (Tests …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8.1.1-jdk17 as builder
 USER root
 COPY . .
-RUN gradle --no-daemon build
+RUN gradle --no-daemon build -x test
 
 FROM gcr.io/distroless/java17
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError


### PR DESCRIPTION
Excluding tests when the docker image is built in CD, because Testcontainers is not supported when building the image. Tests still always run in CI before CD is dispatched.